### PR TITLE
Add ADC token helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ A minimalist Python CLI for bulk-generating MP4s from text files using Google Ve
 * Python 3.8+  
 * `gcloud` CLI with Application Default Credentials (ADC) enabled.  
 * The Python libraries listed in `requirements.txt`.
+
+## Environment & Authentication
+
+Configure Application Default Credentials (ADC) with the `gcloud` CLI:
+
+```bash
+gcloud auth application-default login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+After configuration you can verify the credentials and fetch a bearer token by
+running the helper script:
+
+```bash
+python adc_token.py
+```

--- a/adc_token.py
+++ b/adc_token.py
@@ -1,0 +1,12 @@
+import google.auth
+from google.auth.transport.requests import Request
+
+# Load Application Default Credentials (ADC)
+credentials, project_id = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+
+# Refresh the credentials to obtain a valid bearer token
+credentials.refresh(Request())
+
+print(f"Project ID: {project_id}")
+print(f"Access Token: {credentials.token}")
+print(f"Token Expiry: {credentials.expiry}")


### PR DESCRIPTION
## Summary
- add small helper script to refresh a bearer token using ADC
- document how to configure gcloud ADC and call the helper script

## Testing
- `python -m py_compile adc_token.py`


------
https://chatgpt.com/codex/tasks/task_b_6879dc61176c83269ca14f9480e97118