### PR TITLE
Add Veo generation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 A minimalist Python CLI for bulk-generating MP4s from text files using Google Vertex AI Veo. Point it at a folder of `*.txt` prompts, and it will:
 
-1. Kick off a `predictLongRunning` job for each prompt.  
-2. Poll the operation until it’s complete.  
-3. Decode the base64 video payload.  
+1. Kick off a `predictLongRunning` job for each prompt.
+2. Poll the operation until it’s complete.
+3. Decode the base64 video payload.
 4. Save each result as `{promptName}.mp4`.
 
 ## **Key Points**
 
-* **Zero-config aside from ADC:** Just run `gcloud auth application-default login` and set your project.  
-* **Batch-oriented:** Processes every text file in a directory in one go.  
-* **Resilient:** Logs failures per file and continues with the rest of the batch.  
+* **Zero-config aside from ADC:** Just run `gcloud auth application-default login` and set your project.
+* **Batch-oriented:** Processes every text file in a directory in one go.
+* **Resilient:** Logs failures per file and continues with the rest of the batch.
 * **Extensible:** Designed to be easily modified. You can swap in GCS for output, or tweak parameters like duration, region, and model via CLI flags.
 
 ## **Requirements**
 
-* Python 3.8+  
-* `gcloud` CLI with Application Default Credentials (ADC) enabled.  
+* Python 3.8+
+* `gcloud` CLI with Application Default Credentials (ADC) enabled.
 * The Python libraries listed in `requirements.txt`.
 
 ## Environment & Authentication
@@ -29,9 +29,25 @@ gcloud auth application-default login
 gcloud config set project YOUR_PROJECT_ID
 ```
 
-After configuration you can verify the credentials and fetch a bearer token by
-running the helper script:
+After configuration you can verify the credentials and fetch a bearer token by running the helper script:
 
 ```bash
 python adc_token.py
 ```
+
+## Running the CLI
+
+Use `generate_veo3.py` to process every `*.txt` file in a folder:
+
+```bash
+python generate_veo3.py all ./prompts --duration 6 --count 2
+```
+
+CLI options:
+
+* `folder` – path to the prompt files.
+* `--model` – Vertex model ID (default `veo-3.0-generate-preview`).
+* `--location` – region for the request (default `us-central1`).
+* `--duration` – video duration in seconds (default `8`).
+* `--count` – number of samples to generate (default `1`).
+* `--poll` – polling interval in seconds (default `5`).

--- a/generate_veo3.py
+++ b/generate_veo3.py
@@ -1,0 +1,98 @@
+import base64
+import json
+import time
+from pathlib import Path
+from typing import List
+
+import google.auth
+from google.auth.transport.requests import Request
+import requests
+import typer
+
+app = typer.Typer(help="Bulk generate videos using Vertex AI Veo")
+
+API_URL = (
+    "https://{location}-aiplatform.googleapis.com/v1/"
+    "projects/{project}/locations/{location}/publishers/google/models/{model}:predictLongRunning"
+)
+
+
+def _get_token() -> tuple[str, str]:
+    credentials, project_id = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    credentials.refresh(Request())
+    return credentials.token, project_id
+
+
+def _submit_prompt(prompt: str, *, token: str, project: str, location: str, model: str, duration: int, count: int) -> str:
+    url = API_URL.format(project=project, location=location, model=model)
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    body = {
+        "instances": [{"prompt": prompt, "videoConfig": {"duration": f"{duration}s"}}],
+        "parameters": {"sampleCount": count},
+    }
+    resp = requests.post(url, headers=headers, json=body, timeout=30)
+    resp.raise_for_status()
+    return resp.json()["name"]
+
+
+def _poll_operation(name: str, *, token: str, poll: int) -> dict:
+    url = f"https://aiplatform.googleapis.com/v1/{name}"
+    headers = {"Authorization": f"Bearer {token}"}
+    while True:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("done"):
+            return data
+        time.sleep(poll)
+
+
+def _save_result(result: dict, outfile: Path) -> None:
+    try:
+        b64_data = result["response"]["predictions"][0]["bytes"]
+    except KeyError:
+        raise RuntimeError("Unexpected response format")
+    binary = base64.b64decode(b64_data)
+    outfile.write_bytes(binary)
+
+
+@app.command()
+def all(
+    folder: Path,
+    model: str = "veo-3.0-generate-preview",
+    location: str = "us-central1",
+    duration: int = 8,
+    count: int = 1,
+    poll: int = 5,
+) -> None:
+    """Generate videos for every .txt prompt in FOLDER."""
+    token, project = _get_token()
+    txt_files: List[Path] = sorted(folder.glob("*.txt"))
+    if not txt_files:
+        typer.echo("No prompt files found", err=True)
+        raise typer.Exit(code=1)
+
+    for prompt_file in txt_files:
+        prompt = prompt_file.read_text().strip()
+        typer.echo(f"Submitting {prompt_file.name}...")
+        try:
+            op_name = _submit_prompt(
+                prompt,
+                token=token,
+                project=project,
+                location=location,
+                model=model,
+                duration=duration,
+                count=count,
+            )
+            typer.echo(f"Operation: {op_name}")
+            result = _poll_operation(op_name, token=token, poll=poll)
+            out_mp4 = prompt_file.with_suffix(".mp4")
+            _save_result(result, out_mp4)
+            typer.echo(f"Saved {out_mp4}")
+        except Exception as e:  # noqa: BLE001
+            typer.echo(f"Failed to process {prompt_file.name}: {e}", err=True)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- add `generate_veo3.py` Typer CLI for batch Veo requests
- document how to run the CLI in README

## Testing
- `python -m py_compile adc_token.py generate_veo3.py`


------
https://chatgpt.com/codex/tasks/task_b_6879dcd3a3548326950141631b45f4fa